### PR TITLE
change redis-client library to be cluster compatible

### DIFF
--- a/vertx/example-configs/config-depl.json
+++ b/vertx/example-configs/config-depl.json
@@ -22,13 +22,20 @@
 			"networkRecoveryInterval": 500,
 			"automaticRecoveryEnabled": true
 		},
-		{
-			"id": "iudx.ingestion.pipeline.redis.RedisVerticle",
-			"verticleInstances": 1,
-			"endpoint": "",
-			"redisIp":"",
-			"redisPort":1234
-		},
+                {
+                        "id": "iudx.ingestion.pipeline.redis.RedisVerticle",
+                        "verticleInstances": 1,
+                        "redisMode": "CLUSTER",
+                        "redisUsername": "xyz",
+                        "redisPassword": "abcd",
+                        "redisMaxPoolSize": 30,
+                        "redisMaxPoolWaiting": 200,
+                        "redisMaxWaitingHandlers": 1024,
+                        "redisPoolRecycleTimeout": 1500,
+                        "redisHost":"redis-redis-cluster.redis.svc.cluster.local",
+                        "redisPort": 6379
+                },
+
 		{
 			"id": "iudx.ingestion.pipeline.processor.ProcessorVerticle",
 			"verticleInstances": 1

--- a/vertx/example-configs/config-dev.json
+++ b/vertx/example-configs/config-dev.json
@@ -18,13 +18,20 @@
 			"networkRecoveryInterval": 500,
 			"automaticRecoveryEnabled": true
 		},
-		{
-			"id": "iudx.ingestion.pipeline.redis.RedisVerticle",
-			"verticleInstances": 1,
-			"endpoint": "",
-			"redisIp":"",
-			"redisPort":1234
-		},
+                {
+                        "id": "iudx.ingestion.pipeline.redis.RedisVerticle",
+                        "verticleInstances": 1,
+                        "redisMode": "CLUSTER",
+                        "redisUsername": "xyz",
+                        "redisPassword": "abcd",
+                        "redisMaxPoolSize": 30,
+                        "redisMaxPoolWaiting": 200,
+                        "redisMaxWaitingHandlers": 1024,
+                        "redisPoolRecycleTimeout": 1500,
+                        "redisHost":"redis-redis-cluster.redis.svc.cluster.local",
+                        "redisPort": 6379
+                },
+
 		{
 			"id": "iudx.ingestion.pipeline.processor.ProcessorVerticle",
 			"verticleInstances": 1

--- a/vertx/pom.xml
+++ b/vertx/pom.xml
@@ -8,7 +8,7 @@
 	<name>iudx-ingestion-pipeline</name>
 
 	<properties>
-		<vertx.version>3.9.0</vertx.version>
+		<vertx.version>3.9.8</vertx.version>
 		<openjdk.version>11</openjdk.version>
 		<hazelcast.version>3.6.3</hazelcast.version>
 		<micrometer.version>1.5.2</micrometer.version>
@@ -134,13 +134,12 @@
 			<artifactId>vertx-rabbitmq-client</artifactId>
 			<version>${vertx.version}</version>
 		</dependency>
-		<!-- <dependency> <groupId>io.vertx</groupId> <artifactId>vertx-redis-client</artifactId> 
-			</dependency> -->
 		<dependency>
-			<groupId>com.redislabs</groupId>
-			<artifactId>jrejson</artifactId>
-			<version>1.3.0</version>
+			<groupId>io.vertx</groupId>
+			<artifactId>vertx-redis-client</artifactId>
+			<version>${vertx.version}</version>
 		</dependency>
+		
 	</dependencies>
 
 	<build>

--- a/vertx/src/main/java/iudx/ingestion/pipeline/redis/RedisProducer.java
+++ b/vertx/src/main/java/iudx/ingestion/pipeline/redis/RedisProducer.java
@@ -3,20 +3,19 @@ package iudx.ingestion.pipeline.redis;
 import static iudx.ingestion.pipeline.common.Constants.EB_PUBLISH_2_REDIS;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeParseException;
-import java.util.HashMap;
-import java.util.Map;
-import com.google.gson.Gson;
-import com.google.gson.JsonParseException;
-import com.google.gson.JsonParser;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonObject;
 import iudx.ingestion.pipeline.common.IProducer;
+
 
 
 class RedisProducer implements IProducer {
 
   private final Vertx vertx;
   private final RedisClient redisClient;
+  private static final Logger LOGGER = LogManager.getLogger(RedisProducer.class);
 
 
   public RedisProducer(Vertx vertx, RedisClient client) {
@@ -32,53 +31,62 @@ class RedisProducer implements IProducer {
 
 
   private void publish() {
-    vertx.eventBus().consumer(EB_PUBLISH_2_REDIS, msg -> {
-      if (msg.body() != null) {
-        JsonObject fromEventBus = new JsonObject(msg.body().toString());
-        String messageKey = fromEventBus.getString("key");
-        
-        redisClient.get(messageKey, ".").onComplete(handler -> {
-          if (handler.succeeded()) {
-            // key found
-            System.out.println("key found : "+messageKey);
-            JsonObject fromRedis = handler.result();
-            // if (isValidMessage2Push(fromRedis, fromEventBus)) {
-            StringBuilder pathParam = new StringBuilder();
-            pathParam.append(".")
-                .append(messageKey)
-                .append(".")
-                .append(fromEventBus.getString("path_param"));
-            String message=fromEventBus.getJsonObject("data").toString();
-            com.google.gson.JsonObject json=new Gson().fromJson(message, com.google.gson.JsonObject.class);
-            redisClient.put(messageKey, pathParam.toString(), (Object) json);
-            // }
-          } else {
-            // key not found
-            System.out.println("key not found : "+messageKey);
-            Map<String,Object> origin =new HashMap<String, Object>();
-            Map<String,Object> origin2=new HashMap<String,Object>();
-            origin2.put(fromEventBus.getString("path_param"), new JsonObject());
-            origin.put(messageKey, origin2);
-            
-            //put first entry for RG
-            redisClient.put(messageKey, ".",(Object) origin).onComplete(firstEntryHandler -> {
-              if (firstEntryHandler.succeeded()) {
-                StringBuilder pathParam = new StringBuilder();
-                pathParam.append(".")
-                    .append(messageKey)
-                    .append(".")
-                    .append(fromEventBus.getString("path_param"));
-                //push message to redis server
-                String message=fromEventBus.getJsonObject("data").toString();
-                com.google.gson.JsonObject json=new Gson().fromJson(message, com.google.gson.JsonObject.class);
-                redisClient.put(messageKey, pathParam.toString(), (Object) json);
-              }
-            });
-          }
-        });
-      }
-    });
-  }
+      vertx.eventBus().consumer(EB_PUBLISH_2_REDIS, msg -> {
+        if (msg.body() != null) {
+          JsonObject fromEventBus = new JsonObject(msg.body().toString());
+          String messageKey = fromEventBus.getString("key");
+          
+          redisClient.get(messageKey, ".").onComplete(handler -> {
+            if (handler.succeeded()) {
+              // key found
+              LOGGER.debug("key found : " + messageKey);
+              JsonObject fromRedis = handler.result();
+              LOGGER.debug("data : " + fromRedis.toString());
+              // if (isValidMessage2Push(fromRedis, fromEventBus)) {
+              StringBuilder pathParam = new StringBuilder();
+              pathParam.append(".")
+                  .append(messageKey)
+                  .append(".")
+                  .append(fromEventBus.getString("path_param"));
+              String message=fromEventBus.getJsonObject("data").toString();
+              redisClient.put(messageKey, pathParam.toString(), message).onComplete(res-> {
+                if(res.failed()) {
+                LOGGER.error(res.cause());
+                }
+              });
+              // }
+            } else {
+              // key not found
+              LOGGER.debug("key not found : " + messageKey);
+              JsonObject origin = new JsonObject();
+              origin.put(messageKey,
+                  new JsonObject().put(fromEventBus.getString("path_param"), new JsonObject()));
+              
+              //put first entry for RG
+              redisClient.put(messageKey, ".", origin.toString()).onComplete(firstEntryHandler -> {
+                if (firstEntryHandler.succeeded()) {
+                  StringBuilder pathParam = new StringBuilder();
+                  pathParam.append(".")
+                      .append(messageKey)
+                      .append(".")
+                      .append(fromEventBus.getString("path_param"));
+                  //push message to redis server
+                  String message=fromEventBus.getJsonObject("data").toString();
+                  redisClient.put(messageKey, pathParam.toString(), message).onComplete(res-> {
+                  if(res.failed()) {
+                  LOGGER.error(res.cause());
+                  }
+                });
+                }
+                else {
+                  LOGGER.error(firstEntryHandler.cause());
+                }
+              });
+            }
+          });
+        }
+      });
+    }
 
 
 
@@ -93,8 +101,7 @@ class RedisProducer implements IProducer {
     String dateFromRedisData = fromRedis.getString("observationDateTime");
     String dateFromLatestData = latestJson.getString("observationDateTime");
     boolean result = Boolean.FALSE;
-    System.out
-        .println("from Redis : " + dateFromRedisData + " from Latest : " + dateFromLatestData);
+    LOGGER.debug("from Redis : " + dateFromRedisData + " from Latest : " + dateFromLatestData);
     try {
       ZonedDateTime fromRedisData = ZonedDateTime.parse(dateFromRedisData);
       ZonedDateTime fromLatestData = ZonedDateTime.parse(dateFromLatestData);
@@ -104,9 +111,9 @@ class RedisProducer implements IProducer {
       }
     } catch (DateTimeParseException e) {
       result = Boolean.FALSE;
-    }
+      }
     return result;
-  }
-  
+    }
 
-}
+
+  }

--- a/vertx/src/main/java/iudx/ingestion/pipeline/redis/RedisVerticle.java
+++ b/vertx/src/main/java/iudx/ingestion/pipeline/redis/RedisVerticle.java
@@ -12,7 +12,7 @@ public class RedisVerticle extends AbstractVerticle {
   @Override
   public void start() throws Exception {
     RedisClient client =
-        new RedisClient(vertx, config().getString("redisIp"), config().getInteger("redisPort"));
+        new RedisClient(vertx, config());
 
     redisProducer=new RedisProducer(vertx, client);
     redisProducer.start();

--- a/vertx/src/main/resources/log4j2.xml
+++ b/vertx/src/main/resources/log4j2.xml
@@ -13,7 +13,7 @@
         </Console>
     </Appenders>
     <Loggers>
-        <logger name="iudx.file.server" level="${env:LOG_LEVEL:-DEBUG}"
+        <logger name="iudx.ingestion.pipeline" level="${env:LOG_LEVEL:-DEBUG}"
             additivity="false">
             <appender-ref ref="ConsoleAppender" />
         </logger>


### PR DESCRIPTION
- Use of [vertx-redis-client-3.9.8](https://vertx.io/docs/3.9.8/apidocs/io/vertx/redis/client/package-summary.html) instead of [JRedisJSON client library](https://github.com/RedisJSON/JRedisJSON) ([as JRedisJSON doesn't support clustering]( https://github.com/RedisJSON/JRedisJSON/issues/21)).
- Define and use of JSON.GET and JSON.SET commands using [Command.create](https://vertx.io/docs/3.9.8/apidocs/io/vertx/redis/client/Command.html#create-java.lang.String-int-int-int-int-boolean-boolean-) - 
   - [Support for ReJSON in vertx-redis-client](https://github.com/vert-x3/vertx-redis-client/issues/121)
   - [Vertx Redis client Clustering mode](https://vertx.io/docs/3.9.8/vertx-redis-client/java/#_cluster_mode), 
   - [Command Interface](https://vertx.io/docs/3.9.8/apidocs/io/vertx/redis/client/Command.html)
  -  [Redis Command documentation](https://redis.io/commands/command) - Do  `COMMAND INFO JSON.GET`, `COMMAND INFO JSON.SET` in redis-rejson server to find out the appropriate flags and parameters needed for command.create in vertx-redis-client
- Upgrade to latest 3.9.x version i.e. 3.9.8 as [cluster client authentication is supported >= 3.9.5](https://github.com/vert-x3/vertx-redis-client/issues/270)

Some advantages of Redis clustering:
- High performance and linear scalability up to 1000 nodes. The ability to automatically split your dataset among multiple nodes.
- Acceptable degree of write safety: the system tries (in a best-effort way) to retain all the writes originating from clients connected with the majority of the master nodes. Usually there are small windows where acknowledged writes can be lost. Windows to lose acknowledged writes are larger when clients are in a minority partition.
-  Availability: Redis Cluster is able to survive partitions where the majority of the master nodes are reachable and there is at least one reachable slave for every master node that is no longer reachable.

Some Limitations of Redis clustering, 
- Multi-key operations like Set type unions or intersections or MGET or JSON.MGET are implemented as long as the keys all hash to the same slot. Hashing to same slot can be achieved through hash tags.
- Multi-database not supported. See more at [Redis cluster spec](https://redis.io/topics/cluster-spec)

NOTE: All functions should work as intended as a standalone redis in clustered redis also, except for above limitations. Therefore the testing can  be done using standalone, as long as the above is not used in our application.

Hopefully vertx-redis-client should be sufficient for querying using Rejson commands and for clustering.

This code was tested against Redis standalone (using [redis-rejosn docker](https://hub.docker.com/r/redislabs/rejson/) ) and cluster mode (in K8s, [redis-cluster bitnami chart with Rejson module loaded](https://github.com/bitnami/charts/tree/master/bitnami/redis-cluster) .). In both the cases it works as expected.
Please review,  I'm not so good at vertx. 
