### PR TITLE
Change openjdk base image due to depreciation

### DIFF
--- a/vertx/docker/depl.dockerfile
+++ b/vertx/docker/depl.dockerfile
@@ -2,7 +2,7 @@
 
 ARG VERSION="0.0.1-SNAPSHOT"
 # Using maven base image in builder stage to build Java code.
-FROM maven:3-openjdk-11-slim as builder
+FROM maven:3-eclipse-temurin-11 as builder
 
 WORKDIR /usr/share/app
 COPY pom.xml .
@@ -14,7 +14,7 @@ COPY src src
 RUN mvn clean package -Dmaven.test.skip=true
 
 # Java Runtime as the base for final image
-FROM openjdk:11-jre-slim-buster
+FROM eclipse-temurin:11-jre-focal
 
 ARG VERSION
 ENV JAR="iudx.ingestion.pipeline-cluster-${VERSION}-fat.jar"

--- a/vertx/docker/dev.dockerfile
+++ b/vertx/docker/dev.dockerfile
@@ -2,7 +2,7 @@
 
 ARG VERSION="0.0.1-SNAPSHOT"
 # Using maven base image in builder stage to build Java code.
-FROM maven:3-openjdk-11-slim as builder
+FROM maven:3-eclipse-temurin-11 as builder
 
 WORKDIR /usr/share/app
 COPY pom.xml .
@@ -14,7 +14,7 @@ COPY src src
 RUN mvn clean package -Dmaven.test.skip=true
 
 # Java Runtime as the base for final image
-FROM openjdk:11-jre-slim-buster
+FROM eclipse-temurin:11-jre-focal
 
 ARG VERSION
 ENV JAR="iudx.ingestion.pipeline-dev-${VERSION}-fat.jar"


### PR DESCRIPTION
- Updated openjdk, maven docker image with eclipse-temurin
- The openjdk image is officially deprecated - https://hub.docker.com/_/openjdk
- Hence, migrated base image to Eclipse-temurin
  - https://hub.docker.com/_/eclipse-temurin, maintained by https://github.com/adoptium/containers