### PR TITLE
Seperated automatic docker image tag workflows

### DIFF
--- a/.github/workflows/docker-image-stable.yml
+++ b/.github/workflows/docker-image-stable.yml
@@ -1,0 +1,49 @@
+# This github workflow will automatically update docker image tags of lip-depl in the datakaveri/iudx-deployment repository files,
+# whenever a docker image is pushed to ghcr.io/datakaveri/lip-depl with the tag 5.5.0. This will update the 5.5.0 release branch.
+
+name: Update LIP docker image tags (5.5.0)
+
+# Trigger on new package published to registry
+on:
+  registry_package:
+    types: [published]
+
+permissions:
+  packages: read
+
+jobs:
+  update-release:
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        repository: datakaveri/iudx-deployment
+        token: "${{ secrets.JENKINS_UPDATE }}"
+        fetch-depth: 0
+
+    - name: Update LIP docker image tags for 5.5.0 release
+      env: 
+        GH_TOKEN: ${{ secrets.JENKINS_UPDATE }}
+      run: | 
+        export newtag5_5_0=`(head -n1 <(curl -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" https://api.github.com/orgs/datakaveri/packages/container/lip-depl/versions | jq ' .[].metadata.container.tags[0]' | grep 5.5.0 | grep -v alpha | sed -e 's/^"//' -e 's/"$//'))`
+        export oldtag5_5_0=`yq -r .services.lip.image Docker-Swarm-deployment/single-node/lip/lip-stack.yaml | cut -d : -f 2`
+
+        if [ "$newtag5_5_0" != "$oldtag5_5_0" ]
+        then
+          git checkout 5.5.0
+          git checkout -b lip-5.5.0-automatic-updates/$newtag5_5_0
+          
+          sed -i s/$oldtag5_5_0/$newtag5_5_0/g Docker-Swarm-deployment/single-node/lip/lip-stack.yaml
+          
+          export oldappversion=`yq -r .version K8s-deployment/Charts/latest-ingestion-pipeline/Chart.yaml`
+          export newappversion=`yq -r .version K8s-deployment/Charts/latest-ingestion-pipeline/Chart.yaml | awk -F. -v OFS=. 'NF==1{print ++$NF}; NF>1{if(length($NF+1)>length($NF))$(NF-1)++; $NF=sprintf("%0*d", length($NF), ($NF+1)%(10^length($NF))); print}'`
+          
+          sed -i s/$oldappversion/$newappversion/g K8s-deployment/Charts/latest-ingestion-pipeline/Chart.yaml
+          sed -i s/$oldtag5_5_0/$newtag5_5_0/g K8s-deployment/Charts/latest-ingestion-pipeline/values.yaml
+          
+          git add Docker-Swarm-deployment/single-node/lip/lip-stack.yaml K8s-deployment/Charts/latest-ingestion-pipeline/values.yaml K8s-deployment/Charts/latest-ingestion-pipeline/Chart.yaml
+          git commit --allow-empty -m "updated LIP docker image tag to $newtag5_5_0"
+          git push --set-upstream origin lip-5.5.0-automatic-updates/$newtag5_5_0
+          
+          gh pr create -R datakaveri/iudx-deployment --base 5.5.0 --fill 
+        fi

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,95 +1,49 @@
-# This github workflow will automatically update docker image tags of lip-depl in the datakaveri/iudx-deployment repository files, whenever docker image is pushed to ghcr.io/datakaveri/lip-depl .Based on tag it will update the master/latest branch (if its 5.5.1-alpha-) or 5.5.0 stable branch (if its 5.5.0-)
+# This github workflow will automatically update docker image tags of lip-depl in the datakaveri/iudx-deployment repository files,
+# whenever a docker image is pushed to ghcr.io/datakaveri/lip-depl with the tag 5.6.0-alpha. This will update the master/main branch.
 
-name: Update LIP docker image tags
+name: Update LIP docker image tags (master)
 
-# This trigger will run the workflow whenever a new package is published to the registry
+# Trigger on new package published to registry
 on:
   registry_package:
     types: [published]
 
-# This is needed to read the registry packages     
 permissions:
   packages: read
 
 jobs:
-
-  build:
+  update-main:
     runs-on: ubuntu-20.04
-
     steps:
     - uses: actions/checkout@v3
       with:
-       repository: datakaveri/iudx-deployment
-       # Jenkins token to perform git operations
-       token: "${{ secrets.JENKINS_UPDATE }}"
-       fetch-depth: 0
-    # This step updates the LIP Server docker image tags
-    - name: Update LIP docker image tags
+        repository: datakaveri/iudx-deployment
+        token: "${{ secrets.JENKINS_UPDATE }}"
+        fetch-depth: 0
+
+    - name: Update LIP docker image tags for master
       env: 
-        GH_TOKEN: ${{ secrets.JENKINS_UPDATE}}
+        GH_TOKEN: ${{ secrets.JENKINS_UPDATE }}
       run: | 
-        # Get the latest version of 5.5.0 and 5.5.1-alpha tags from the container registry using GitHub API
-        export newtag5_5_1=`(head -n1 <(curl -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" https://api.github.com/orgs/datakaveri/packages/container/lip-depl/versions | jq ' .[].metadata.container.tags[0]'  | grep 5.5.1-alpha | sed -e 's/^"//' -e 's/"$//'))`
-        export newtag5_5_0=`(head -n1 <(curl -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" https://api.github.com/orgs/datakaveri/packages/container/lip-depl/versions | jq ' .[].metadata.container.tags[0]'  | grep 5.5.0 | grep -v alpha | sed -e 's/^"//' -e 's/"$//'))`
+        export newtag5_6_0_alpha=`(head -n1 <(curl -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" https://api.github.com/orgs/datakaveri/packages/container/lip-depl/versions | jq ' .[].metadata.container.tags[0]' | grep 5.6.0-alpha | sed -e 's/^"//' -e 's/"$//'))`
+        export oldtag5_6_0_alpha=`yq -r .services.lip.image Docker-Swarm-deployment/single-node/lip/lip-stack.yaml | cut -d : -f 2`
 
-        # Get the old tags from the YAML files
-        export oldtag5_5_1=`yq -r .services.lip.image Docker-Swarm-deployment/single-node/lip/lip-stack.yaml | cut -d : -f 2`
-        git checkout 5.5.0
-        export oldtag5_5_0=$(yq -r .services.lip.image Docker-Swarm-deployment/single-node/lip/lip-stack.yaml | cut -d : -f 2)      
-        
-         # Set Git user
-        git config --global user.name 'jenkins-datakaveri'
-        git config --global user.email "96175780+jenkins-datakaveri@users.noreply.github.com"
-
-
-        # Update the YAML files and create a new branch for each tag update
-        if [ "$newtag5_5_0" != "$oldtag5_5_0" ]
+        if [ "$newtag5_6_0_alpha" != "$oldtag5_6_0_alpha" ]
         then
-         git checkout -b lip-5.5.0-automatic-updates/$newtag5_5_0
-
-         # Uses sed to find and replace $oldtag5_5_0 with $newtag5_5_0 in Docker-Swarm-deployment/single-node/lip/lip-stack.yaml file
-         sed -i s/$oldtag5_5_0/$newtag5_5_0/g Docker-Swarm-deployment/single-node/lip/lip-stack.yaml
-         
-         # Exports the current version of the application from K8s-deployment/Charts/latest-ingestion-pipeline/Chart.yaml file
-         export oldappversion=`yq -r .version K8s-deployment/Charts/latest-ingestion-pipeline/Chart.yaml`
-         
-         # Uses awk to increment the version number in K8s-deployment/Charts/latest-ingestion-pipeline/Chart.yaml file
-         export newappversion=`yq -r .version K8s-deployment/Charts/latest-ingestion-pipeline/Chart.yaml | awk -F. -v OFS=. 'NF==1{print ++$NF}; NF>1{if(length($NF+1)>length($NF))$(NF-1)++; $NF=sprintf("%0*d", length($NF), ($NF+1)%(10^length($NF))); print}' `
-         
-         # Uses sed to find and replace $oldappversion with $newappversion in K8s-deployment/Charts/latest-ingestion-pipeline/Chart.yaml and K8s-deployment/Charts/latest-ingestion-pipeline/values.yaml files
-         sed -i s/$oldappversion/$newappversion/g K8s-deployment/Charts/latest-ingestion-pipeline/Chart.yaml
-         sed -i s/$oldtag5_5_0/$newtag5_5_0/g K8s-deployment/Charts/latest-ingestion-pipeline/values.yaml
-         git add Docker-Swarm-deployment/single-node/lip/lip-stack.yaml K8s-deployment/Charts/latest-ingestion-pipeline/values.yaml K8s-deployment/Charts/latest-ingestion-pipeline/Chart.yaml
-         git commit --allow-empty -m "updated lip docker image tag to $newtag5_5_0"
-         git push --set-upstream origin lip-5.5.0-automatic-updates/$newtag5_5_0
-         
-         # Creates a new pull request on the datakaveri/iudx-deployment repository with the base branch 5.5.0
-         gh pr create -R datakaveri/iudx-deployment --base 5.5.0 --fill 
+          git checkout master
+          git checkout -b lip-automatic-updates/$newtag5_6_0_alpha
+          
+          sed -i s/$oldtag5_6_0_alpha/$newtag5_6_0_alpha/g Docker-Swarm-deployment/single-node/lip/lip-stack.yaml
+          
+          export oldappversion=`yq -r .version K8s-deployment/Charts/latest-ingestion-pipeline/Chart.yaml`
+          export newappversion=`yq -r .version K8s-deployment/Charts/latest-ingestion-pipeline/Chart.yaml | awk -F. -v OFS=. 'NF==1{print ++$NF}; NF>1{if(length($NF+1)>length($NF))$(NF-1)++; $NF=sprintf("%0*d", length($NF), ($NF+1)%(10^length($NF))); print}'`
+          
+          sed -i s/$oldappversion/$newappversion/g K8s-deployment/Charts/latest-ingestion-pipeline/Chart.yaml
+          sed -i s/$oldtag5_6_0_alpha/$newtag5_6_0_alpha/g K8s-deployment/Charts/latest-ingestion-pipeline/values.yaml
+          
+          git add Docker-Swarm-deployment/single-node/lip/lip-stack.yaml K8s-deployment/Charts/latest-ingestion-pipeline/values.yaml K8s-deployment/Charts/latest-ingestion-pipeline/Chart.yaml
+          git commit --allow-empty -m "updated LIP docker image tag to $newtag5_6_0_alpha"
+          git push --set-upstream origin lip-automatic-updates/$newtag5_6_0_alpha
+          
+          gh pr create -R datakaveri/iudx-deployment --base master --fill 
         fi
-        
-        if [ "$newtag5_5_1" != "$oldtag5_5_1" ]
-        then
-         git checkout master
-         git checkout -b lip-automatic-updates/$newtag5_5_1
-
-         # Uses sed to find and replace $oldtag5_5_1 with $newtag5_5_1 in Docker-Swarm-deployment/single-node/lip/lip-stack.yaml file
-         sed -i s/$oldtag5_5_1/$newtag5_5_1/g Docker-Swarm-deployment/single-node/lip/lip-stack.yaml
-         
-         # Exports the current version of the application from K8s-deployment/Charts/latest-ingestion-pipeline/Chart.yaml file
-         export oldappversion=`yq -r .version K8s-deployment/Charts/latest-ingestion-pipeline/Chart.yaml`
-         
-         # Uses awk to increment the version number in K8s-deployment/Charts/latest-ingestion-pipeline/Chart.yaml file
-         export newappversion=`yq -r .version K8s-deployment/Charts/latest-ingestion-pipeline/Chart.yaml | awk -F. -v OFS=. 'NF==1{print ++$NF}; NF>1{if(length($NF+1)>length($NF))$(NF-1)++; $NF=sprintf("%0*d", length($NF), ($NF+1)%(10^length($NF))); print}' `
-         
-         # Uses sed to find and replace $oldappversion with $newappversion in K8s-deployment/Charts/latest-ingestion-pipeline/Chart.yaml and K8s-deployment/Charts/latest-ingestion-pipeline/values.yaml files
-         sed -i s/$oldappversion/$newappversion/g K8s-deployment/Charts/latest-ingestion-pipeline/Chart.yaml
-         sed -i s/$oldtag5_5_1/$newtag5_5_1/g K8s-deployment/Charts/latest-ingestion-pipeline/values.yaml
-         git add Docker-Swarm-deployment/single-node/lip/lip-stack.yaml K8s-deployment/Charts/latest-ingestion-pipeline/values.yaml K8s-deployment/Charts/latest-ingestion-pipeline/Chart.yaml
-         git commit --allow-empty -m "updated lip docker image tag to $newtag5_5_1"
-         git push --set-upstream origin lip-automatic-updates/$newtag5_5_1
-         
-         # Creates a new pull request on the datakaveri/iudx-deployment repository with the base branch master
-         gh pr create -R datakaveri/iudx-deployment --base master --fill 
-        fi
-
-

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -42,8 +42,8 @@ pipeline {
           steps {
             script {
               docker.withRegistry( registryUri, registryCredential ) {
-                devImage.push("5.5.0-alpha-${env.GIT_HASH}")
-                deplImage.push("5.5.0-alpha-${env.GIT_HASH}")
+                devImage.push("5.6.0-alpha-${env.GIT_HASH}")
+                deplImage.push("5.6.0-alpha-${env.GIT_HASH}")
               }
             }
           }
@@ -51,7 +51,7 @@ pipeline {
         stage('Docker Swarm deployment') {
           steps {
             script {
-              sh "ssh azureuser@docker-swarm 'docker service update lip_lip --image ghcr.io/datakaveri/lip-depl:5.5.0-alpha-${env.GIT_HASH}'"
+              sh "ssh azureuser@docker-swarm 'docker service update lip_lip --image ghcr.io/datakaveri/lip-depl:5.6.0-alpha-${env.GIT_HASH}'"
               sh 'sleep 10'
             }
           }


### PR DESCRIPTION
- This github workflow will automatically update docker image tags of lip-depl in the datakaveri/iudx-deployment repository files, whenever a docker image is pushed to ghcr.io/datakaveri/lip-depl with the tag 5.6.0-alpha. This will update the master/main branch.
- This github workflow will automatically update docker image tags of lip-depl in the datakaveri/iudx-deployment repository files, whenever a docker image is pushed to ghcr.io/datakaveri/lip-depl with the tag 5.5.0. This will update the 5.5.0 release branch.

https://github.com/datakaveri/iudx-deployment/issues/721